### PR TITLE
Add option to monitor propulsion.*.state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 .vscode/
+/.project


### PR DESCRIPTION
Many users will not have nmea signals from their engine - and therefore wont have `propulsion.*.revolutions` signals. But they might be using a plugin such as [signalk-alternator-engine-on](https://github.com/meri-imperiumi/signalk-alternator-engine-on) which emits `propulsion.*.state` =  'started' when it detects that the engine is running.

I've made light changes to the plugin to permit either signal to drive the engine hour counter.